### PR TITLE
1.16.5へのポート

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.12.2-R0.1-SNAPSHOT</version>
+      <version>1.16.5-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/azisaba/psgui/inventory/ClickableGUI.java
+++ b/src/main/java/net/azisaba/psgui/inventory/ClickableGUI.java
@@ -3,6 +3,7 @@ package net.azisaba.psgui.inventory;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 
 public abstract class ClickableGUI {
 
@@ -14,7 +15,7 @@ public abstract class ClickableGUI {
 
     public abstract void onClickInventory(InventoryClickEvent e);
 
-    public boolean isSameInventory(Inventory inv) {
-        return inv.getSize() == getSize() && getTitle().equals(inv.getTitle());
+    public boolean isSameInventory(InventoryView invView) {
+        return invView.getTopInventory().getSize() == getSize() && getTitle().equals(invView.getTitle());
     }
 }

--- a/src/main/java/net/azisaba/psgui/inventory/ClickableGUIManager.java
+++ b/src/main/java/net/azisaba/psgui/inventory/ClickableGUIManager.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 
 public class ClickableGUIManager {
 
@@ -16,9 +17,9 @@ public class ClickableGUIManager {
         }
     }
 
-    public ClickableGUI getMatchGUI(Inventory inv) {
+    public ClickableGUI getMatchGUI(InventoryView invView) {
         for ( ClickableGUI gui : guiList ) {
-            if ( gui.isSameInventory(inv) ) {
+            if ( gui.isSameInventory(invView) ) {
                 return gui;
             }
         }
@@ -44,7 +45,7 @@ public class ClickableGUIManager {
             }
 
             for ( ClickableGUI gui : guiList ) {
-                if ( gui.getTitle().equals(p.getOpenInventory().getTopInventory().getTitle()) ) {
+                if ( gui.getTitle().equals(p.getOpenInventory().getTitle()) ) {
                     p.closeInventory();
                     return;
                 }

--- a/src/main/java/net/azisaba/psgui/inventory/CratesInventory.java
+++ b/src/main/java/net/azisaba/psgui/inventory/CratesInventory.java
@@ -124,17 +124,17 @@ public class CratesInventory extends ClickableGUI {
 
     private void initItems() {
         if ( addLittle == null ) {
-            addLittle = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 5, Chat.f("&e0.1%&a上げる"));
+            addLittle = ItemHelper.createItem(Material.LIME_STAINED_GLASS_PANE, 5, Chat.f("&e0.1%&a上げる"));
         }
         if ( addLarge == null ) {
-            addLarge = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 13, Chat.f("&e1%&a上げる"));
+            addLarge = ItemHelper.createItem(Material.GREEN_STAINED_GLASS_PANE, 13, Chat.f("&e1%&a上げる"));
         }
 
         if ( subtractLittle == null ) {
-            subtractLittle = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 1, Chat.f("&e0.1%&c下げる"));
+            subtractLittle = ItemHelper.createItem(Material.ORANGE_STAINED_GLASS_PANE, 1, Chat.f("&e0.1%&c下げる"));
         }
         if ( subtractLarge == null ) {
-            subtractLarge = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 14, Chat.f("&e1%&c下げる"));
+            subtractLarge = ItemHelper.createItem(Material.RED_STAINED_GLASS_PANE, 14, Chat.f("&e1%&c下げる"));
         }
 
         if ( backArrow == null ) {
@@ -142,7 +142,7 @@ public class CratesInventory extends ClickableGUI {
         }
 
         if ( muteOwnEnable == null ) {
-            muteOwnEnable = ItemHelper.create(Material.EYE_OF_ENDER, Chat.f("&e自分のログにも適用する &7(&a有効&7)"), Chat.f("&7自分のガチャログも&c上の設定が適用&7されます！"));
+            muteOwnEnable = ItemHelper.create(Material.ENDER_EYE, Chat.f("&e自分のログにも適用する &7(&a有効&7)"), Chat.f("&7自分のガチャログも&c上の設定が適用&7されます！"));
         }
         if ( muteOwnDisable == null ) {
             muteOwnDisable = ItemHelper.create(Material.ENDER_PEARL, Chat.f("&e自分のログにも適用する &7(&c無効&7)"), Chat.f("&7自分のガチャログは確率を問わず&c全て&7チャットに流れます！"));
@@ -168,12 +168,12 @@ public class CratesInventory extends ClickableGUI {
             lore.add(5, "");
         }
 
-        return ItemHelper.create(Material.SIGN, Chat.f("&7表示しない当たりの確率"), lore.toArray(new String[lore.size()]));
+        return ItemHelper.create(Material.OAK_SIGN, Chat.f("&7表示しない当たりの確率"), lore.toArray(new String[lore.size()]));
     }
 
     private void updateInventory(Inventory inv, Player p) {
         ItemStack middleSign = inv.getItem(4);
-        if ( middleSign == null || middleSign.getType() != Material.SIGN ) {
+        if ( middleSign == null || middleSign.getType() != Material.OAK_SIGN ) {
             p.openInventory(createInventory(p));
             return;
         }

--- a/src/main/java/net/azisaba/psgui/inventory/MainInventory.java
+++ b/src/main/java/net/azisaba/psgui/inventory/MainInventory.java
@@ -146,7 +146,7 @@ public class MainInventory extends ClickableGUI {
         return Chat.f("&cPlayer Settings &e- &aMain");
     }
 
-    private final Material enable = Material.EYE_OF_ENDER, disable = Material.ENDER_PEARL;
+    private final Material enable = Material.ENDER_EYE, disable = Material.ENDER_PEARL;
 
     private void initItems() {
         if ( crates == null ) {
@@ -154,12 +154,12 @@ public class MainInventory extends ClickableGUI {
                     Chat.f("&7これは自分の当たりには反映されません"));
         }
         if ( sound == null ) {
-            sound = ItemHelper.create(Material.DIAMOND_SPADE, Chat.f("&6銃の音量設定"), Chat.f("&7銃の音量を調節できます"),
+            sound = ItemHelper.create(Material.DIAMOND_SHOVEL, Chat.f("&6銃の音量設定"), Chat.f("&7銃の音量を調節できます"),
                     Chat.f("&7うるさい場合はこの値を下げてください"));
         }
 
         if ( rankingAno == null ) {
-            rankingAno = ItemHelper.create(Material.SIGN, Chat.f("&cキルランキングを匿名にする"), "",
+            rankingAno = ItemHelper.create(Material.OAK_SIGN, Chat.f("&cキルランキングを匿名にする"), "",
                     Chat.f("&a有効 &7で &4{0} &7に置き換えられます", "{匿名プレイヤー}"), Chat.f("&c無効 &7でMCIDが表示されます"));
         }
         if ( rankingAnoStatusEnable == null ) {
@@ -208,7 +208,7 @@ public class MainInventory extends ClickableGUI {
         }
 
         if ( titleOnPrivateChat == null ) {
-            titleOnPrivateChat = ItemHelper.create(Material.SIGN, Chat.f("&c個人チャット受信時にタイトルを表示する"), "",
+            titleOnPrivateChat = ItemHelper.create(Material.OAK_SIGN, Chat.f("&c個人チャット受信時にタイトルを表示する"), "",
                     Chat.f("&7個人チャットを受け取ったときに画面上にメッセージを表示します"));
         }
         if ( titleOnPrivateChatEnable == null ) {

--- a/src/main/java/net/azisaba/psgui/inventory/SoundControlInventory.java
+++ b/src/main/java/net/azisaba/psgui/inventory/SoundControlInventory.java
@@ -101,7 +101,7 @@ public class SoundControlInventory extends ClickableGUI {
             percent = data.getDouble(key);
         }
 
-        ItemStack sign = ItemHelper.create(Material.SIGN, Chat.f("&7銃声の設定"), "", Chat.f("&a現在の音量: &e{0}%", percent),
+        ItemStack sign = ItemHelper.create(Material.OAK_SIGN, Chat.f("&7銃声の設定"), "", Chat.f("&a現在の音量: &e{0}%", percent),
                 "");
 
         return sign;
@@ -109,17 +109,17 @@ public class SoundControlInventory extends ClickableGUI {
 
     private void initItems() {
         if ( increaseLittle == null ) {
-            increaseLittle = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 5, Chat.f("&a音量を {0} 上げる", 1));
+            increaseLittle = ItemHelper.createItem(Material.LIME_STAINED_GLASS_PANE, 5, Chat.f("&a音量を {0} 上げる", 1));
         }
         if ( increaseLarge == null ) {
-            increaseLarge = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 13, Chat.f("&a音量を {0} 上げる", 5));
+            increaseLarge = ItemHelper.createItem(Material.GREEN_STAINED_GLASS_PANE, 13, Chat.f("&a音量を {0} 上げる", 5));
         }
 
         if ( decreaseLittle == null ) {
-            decreaseLittle = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 1, Chat.f("&c音量を {0} 下げる", 1));
+            decreaseLittle = ItemHelper.createItem(Material.ORANGE_STAINED_GLASS_PANE, 1, Chat.f("&c音量を {0} 下げる", 1));
         }
         if ( decreaseLarge == null ) {
-            decreaseLarge = ItemHelper.createItem(Material.STAINED_GLASS_PANE, 14, Chat.f("&c音量を {0} 下げる", 5));
+            decreaseLarge = ItemHelper.createItem(Material.RED_STAINED_GLASS_PANE, 14, Chat.f("&c音量を {0} 下げる", 5));
         }
 
         if ( backArrow == null ) {

--- a/src/main/java/net/azisaba/psgui/listener/InventoryClickListener.java
+++ b/src/main/java/net/azisaba/psgui/listener/InventoryClickListener.java
@@ -23,8 +23,7 @@ public class InventoryClickListener implements Listener {
         }
 
         Player p = (Player) e.getWhoClicked();
-        Inventory openingInv = e.getInventory();
-        ClickableGUI gui = PlayerSettingsGUI.getPlugin().getGuiManager().getMatchGUI(openingInv);
+        ClickableGUI gui = PlayerSettingsGUI.getPlugin().getGuiManager().getMatchGUI(e.getView());
 
         if ( gui == null ) {
             return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ authors: ["siloneco", "YukiLeafX"]
 description: ${project.description}
 website: ${project.url}
 softdepend: ["PlayerSettings"]
+api-version: 1.16
 commands:
   settings:
     permission: playersettingsgui.command.settings


### PR DESCRIPTION
## 概要
- 1.16.5へのポートをできる限り最小限の変更で行いました。

## 破壊的変更
- Spigot APIを1.12.2 -> 1.16.5にバージョンアップ
   - バージョンアップに伴って、plugin.yml内にapi-versionを記載
- ClickableGUI内のisSameInventoryの引数をInventoryからInventoryViewへ変更(及び関連コードの変更)

## 対応箇所
- Material.STAINED_GLASS_PANEが呼ばれていた場所を、それぞれの色に対応したMaterialに変更
- Material.SIGNをMaterial.OAK_SIGNへ変更
- Material.EYE_OF_ENDERをMaterial.ENDER_EYEに変更

## 動作確認済みの環境
- PaperMC 1.16.5 Build #794